### PR TITLE
Fix problem on windows

### DIFF
--- a/ctrtool/utils.h
+++ b/ctrtool/utils.h
@@ -10,7 +10,7 @@
 #endif
 
 #ifndef MAX_PATH
-	#define MAX_PATH 255
+	#define MAX_PATH 260
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
MAX_PATH is defined in stdlib as 260 on windows.
As some source files included stdlib and some not, it made the program crash because of different sizes of the filepath structure.
You can check it with sizeof(filepath) in romfs.c and settings.h.
Tested on MinGW latest update.
